### PR TITLE
Fix Software77 provider, Fix make lint, Add some routes

### DIFF
--- a/api/self.go
+++ b/api/self.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/http"
 
+	"github.com/go-chi/chi"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/9seconds/topographer/providers"
@@ -17,9 +18,18 @@ func selfResolveIP(w http.ResponseWriter, r *http.Request) {
 	response := ipResolveResponseStruct{
 		Results: make(map[string]*ipResolveItemStruct),
 	}
-	addr := net.ParseIP(r.RemoteAddr)
-	if addr.To4() != nil {
-		results := set.Resolve([]net.IP{net.ParseIP(r.RemoteAddr)}, []string{})
+
+	var ipToResolve net.IP
+	givenIP := chi.URLParam(r, "ip")
+
+	if givenIP == "" {
+		ipToResolve = net.ParseIP(r.RemoteAddr)
+	} else {
+		ipToResolve = net.ParseIP(givenIP)
+	}
+
+	if ipToResolve.To4() != nil {
+		results := set.Resolve([]net.IP{ipToResolve}, []string{})
 		response.Build(results)
 	}
 

--- a/api/server.go
+++ b/api/server.go
@@ -6,9 +6,9 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/9seconds/topographer/providers"
 	"github.com/go-chi/chi"
 	"github.com/go-chi/chi/middleware"
+	"github.com/9seconds/topographer/providers"
 )
 
 type contextKey string
@@ -32,9 +32,12 @@ func MakeServer(set *providers.ProviderSet) *chi.Mux {
 	router.Use(middleware.SetHeader("Content-Type", "application/json"))
 	router.Use(ctxProviderSet)
 
-	router.Get("/", selfResolveIP)
-	router.Post("/", resolveIPs)
 	router.Get("/info", providerInfo)
+	router.Route("/", func(r chi.Router) {
+		r.Get("/{ip}", selfResolveIP)
+		r.Get("/", selfResolveIP)
+		r.Post("/", resolveIPs)
+	})
 
 	return router
 }

--- a/api/structs.go
+++ b/api/structs.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"net"
 
-	"github.com/9seconds/topographer/providers"
 	"github.com/juju/errors"
+	"github.com/9seconds/topographer/providers"
 	"github.com/xrash/smetrics"
 )
 

--- a/providers/csvdb_provider.go
+++ b/providers/csvdb_provider.go
@@ -92,9 +92,8 @@ func addOrSetCIDR(tree *nradix.Tree, cidr string, geoData *GeoResult) error {
 				return errors.Annotate(errSet, "Incorrect IP range")
 			}
 			return nil
-		} else {
-			return errors.Annotate(errAdd, "Incorrect IP range")
 		}
+		return errors.Annotate(errAdd, "Incorrect IP range")
 	}
 	return nil
 }

--- a/providers/csvdb_provider.go
+++ b/providers/csvdb_provider.go
@@ -74,7 +74,7 @@ func (cdp *CSVDBProvider) createDatabase() (*nradix.Tree, error) {
 			}).Warn("Cannot parse ip range")
 		} else {
 			for _, cidr := range subnets {
-				if errAddOrSet := AddOrSetCIDR(tree, cidr, geoData); errAddOrSet != nil {
+				if errAddOrSet := addOrSetCIDR(tree, cidr, geoData); errAddOrSet != nil {
 					return nil, errAddOrSet
 				}
 			}
@@ -84,7 +84,7 @@ func (cdp *CSVDBProvider) createDatabase() (*nradix.Tree, error) {
 	return tree, nil
 }
 
-func AddOrSetCIDR(tree *nradix.Tree, cidr string, geoData *GeoResult) error {
+func addOrSetCIDR(tree *nradix.Tree, cidr string, geoData *GeoResult) error {
 	if errAdd := tree.AddCIDR(cidr, geoData); errAdd != nil {
 		if errAdd == nradix.ErrNodeBusy {
 			log.Infof("CIDR %s for country %s already exists. Try to set the new value", cidr, geoData.Country)

--- a/providers/dbip.go
+++ b/providers/dbip.go
@@ -52,7 +52,7 @@ func (di *DBIP) Update() (bool, error) {
 	return di.saveFile(rawFile)
 }
 
-func LoadSourcesFromUrl(url string) (*goquery.Document, error) {
+func loadSourcesFromURL(url string) (*goquery.Document, error) {
 	// Load the URL
 	res, e := http.Get(url)
 	if e != nil {
@@ -62,7 +62,7 @@ func LoadSourcesFromUrl(url string) (*goquery.Document, error) {
 }
 
 func (di *DBIP) updateGetDownloadLink(url string) (string, error) {
-	doc, err := LoadSourcesFromUrl(url)
+	doc, err := loadSourcesFromURL(url)
 	if err != nil {
 		return "", errors.Annotate(err, "Cannot fetch DBIP HTML page")
 	}

--- a/providers/dbip.go
+++ b/providers/dbip.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"time"
 
+	"net/http"
+
 	"github.com/9seconds/topographer/config"
 	"github.com/9seconds/topographer/csvdb"
 	"github.com/PuerkitoBio/goquery"
@@ -50,8 +52,17 @@ func (di *DBIP) Update() (bool, error) {
 	return di.saveFile(rawFile)
 }
 
+func LoadSourcesFromUrl(url string) (*goquery.Document, error) {
+	// Load the URL
+	res, e := http.Get(url)
+	if e != nil {
+		return nil, e
+	}
+	return goquery.NewDocumentFromReader(res.Body)
+}
+
 func (di *DBIP) updateGetDownloadLink(url string) (string, error) {
-	doc, err := goquery.NewDocument(url)
+	doc, err := LoadSourcesFromUrl(url)
 	if err != nil {
 		return "", errors.Annotate(err, "Cannot fetch DBIP HTML page")
 	}

--- a/providers/maxmind.go
+++ b/providers/maxmind.go
@@ -13,8 +13,8 @@ import (
 	maxminddb "github.com/oschwald/geoip2-golang"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/9seconds/topographer/config"
 	"github.com/juju/errors"
+	"github.com/9seconds/topographer/config"
 )
 
 const (

--- a/providers/provider.go
+++ b/providers/provider.go
@@ -15,8 +15,8 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/9seconds/topographer/config"
 	"github.com/juju/errors"
+	"github.com/9seconds/topographer/config"
 )
 
 // Provider is a structure which represents a basic common data for every

--- a/providers/software77.go
+++ b/providers/software77.go
@@ -8,9 +8,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/juju/errors"
 	"github.com/9seconds/topographer/config"
 	"github.com/9seconds/topographer/csvdb"
-	"github.com/juju/errors"
 )
 
 const (
@@ -38,6 +38,11 @@ func (s77 *Software77) Update() (bool, error) {
 	}()
 
 	return s77.saveFile(rawFile)
+}
+
+// Reopen reopens Software77 database.
+func (s77 *Software77) Reopen(lastUpdated time.Time) (err error) {
+	return s77.CSVDBProvider.Reopen(lastUpdated)
 }
 
 // NewSoftware77 creates new instance of Software77 provider.


### PR DESCRIPTION
Hi,
i've fixed some issues:

- S77 provider does not contain the Reopen function. 
- Error handling: AddCIDR will return an error when the CIDR already exists. I evaluate the error (ErrNodeBusy) and try to update the entry (SetCIDR).
- The route "/{ip}" is added to lookup a single IP via GET method. This seems to be okay because other services have the same functionality.
- Fix make lint errors. Deprecation warnings and gocyclo errors fixed

kind regards,
nesc